### PR TITLE
Fix ProviderID formatting

### DIFF
--- a/pkg/clients/tenantcluster/mock/client_generated.go
+++ b/pkg/clients/tenantcluster/mock/client_generated.go
@@ -5,10 +5,11 @@
 package mock
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	v1 "k8s.io/api/core/v1"
-	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface
@@ -90,4 +91,19 @@ func (m *MockClient) GetNamespace() (string, error) {
 func (mr *MockClientMockRecorder) GetNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockClient)(nil).GetNamespace))
+}
+
+// GetInfraID mocks base method
+func (m *MockClient) GetInfraID() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInfraID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInfraID indicates an expected call of GetInfraID
+func (mr *MockClientMockRecorder) GetInfraID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfraID", reflect.TypeOf((*MockClient)(nil).GetInfraID))
 }

--- a/pkg/managers/vm/machine_scope.go
+++ b/pkg/managers/vm/machine_scope.go
@@ -46,6 +46,8 @@ const (
 	podNetworkName                    = "pod-network"
 )
 
+const providerIDFormat = "kubevirt://%s/%s"
+
 type machineScope struct {
 	infraClusterClient    infracluster.Client
 	tenantClusterClient   tenantcluster.Client
@@ -186,7 +188,7 @@ func (s *machineScope) setProviderID(vm *kubevirtapiv1.VirtualMachine) {
 		return
 	}
 
-	providerID := fmt.Sprintf("kubevirt:///%s/%s", s.getMachineNamespace(), vm.GetName())
+	providerID := formatProviderID(s.getMachineNamespace(), vm.GetName())
 
 	if existingProviderID != nil && *existingProviderID == providerID {
 		klog.Infof("%s: ProviderID already set in the machine Spec with value:%s", s.getMachineName(), *existingProviderID)
@@ -499,4 +501,8 @@ func (s *machineScope) setProviderStatus(vm *kubevirtapiv1.VirtualMachine, vmi *
 // GetMachineName return the name of the provided Machine
 func GetMachineName(machine *machinev1.Machine) string {
 	return machine.GetName()
+}
+
+func formatProviderID(namespace, name string) string {
+	return fmt.Sprintf(providerIDFormat, namespace, name)
 }

--- a/pkg/managers/vm/stubs_test.go
+++ b/pkg/managers/vm/stubs_test.go
@@ -192,18 +192,21 @@ func stubVirtualMachine(machineScope *machineScope) *kubevirtapiv1.VirtualMachin
 		Spec: kubevirtapiv1.VirtualMachineSpec{
 			RunStrategy: &runAlways,
 			DataVolumeTemplates: []cdiv1.DataVolume{
-				*buildBootVolumeDataVolumeTemplate(machineScope.machine.GetName(), machineScope.machineProviderSpec.SourcePvcName, namespace, storageClassName, defaultRequestedStorage, defaultPersistentVolumeAccessMode),
+				*buildBootVolumeDataVolumeTemplate(machineScope.machine.GetName(), machineScope.machineProviderSpec.SourcePvcName, namespace, storageClassName, defaultRequestedStorage, defaultPersistentVolumeAccessMode, map[string]string{"tenantcluster-test-id-asdfg-machine.openshift.io": "owned"}),
 			},
 			Template: vmiTemplate,
 		},
 	}
+
+	labels := machineScope.machine.Labels
+	labels["tenantcluster-test-id-asdfg-machine.openshift.io"] = "owned"
 
 	virtualMachine.APIVersion = APIVersion
 	virtualMachine.Kind = Kind
 	virtualMachine.ObjectMeta = metav1.ObjectMeta{
 		Name:            machineScope.machine.Name,
 		Namespace:       namespace,
-		Labels:          machineScope.machine.Labels,
+		Labels:          labels,
 		Annotations:     machineScope.machine.Annotations,
 		OwnerReferences: nil,
 		ClusterName:     machineScope.machine.ClusterName,

--- a/pkg/managers/vm/vm_test.go
+++ b/pkg/managers/vm/vm_test.go
@@ -397,7 +397,7 @@ func TestUpdate(t *testing.T) {
 			clientUpdateVMError:    nil,
 			emptyGetVM:             false,
 			labels:                 nil,
-			providerID:             fmt.Sprintf("kubevirt:///%s/%s", defaultNamespace, mahcineName),
+			providerID:             formatProviderID(defaultNamespace, mahcineName),
 			wantVMToBeReady:        true,
 		},
 		{
@@ -408,7 +408,7 @@ func TestUpdate(t *testing.T) {
 			clientUpdateVMError:             nil,
 			emptyGetVM:                      false,
 			labels:                          nil,
-			providerID:                      fmt.Sprintf("kubevirt:///%s/%s", defaultNamespace, mahcineName),
+			providerID:                      formatProviderID(defaultNamespace, mahcineName),
 			wantVMToBeReady:                 true,
 			useDefaultCredentialsSecretName: true,
 		},
@@ -538,7 +538,6 @@ func TestUpdate(t *testing.T) {
 				assert.Equal(t, err.Error(), "requeue in: 20s")
 			} else {
 				assert.Equal(t, err, nil)
-				//providerID := fmt.Sprintf("kubevirt:///%s/%s", machineScope.machine.GetNamespace(), machineScope.virtualMachine.GetName())
 				assert.Equal(t, *machine.Spec.ProviderID, tc.providerID)
 			}
 		})

--- a/pkg/managers/vm/vm_test.go
+++ b/pkg/managers/vm/vm_test.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	clusterNamespace = "kubevirt-actuator-cluster"
+	infraID          = "test-id-asdfg"
 )
 
 func initializeMachine(t *testing.T, labels map[string]string, providerID string, useDefaultCredentialsSecretName bool) *machinev1.Machine {
@@ -117,6 +118,7 @@ func TestCreate(t *testing.T) {
 			newMockTenantClusterClient.EXPECT().StatusPatchMachine(machine, machine.DeepCopy()).Return(nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetSecret(workerUserDataSecretName, machine.Namespace).Return(stubSecret(), nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetNamespace().Return(clusterNamespace, nil).AnyTimes()
+			newMockTenantClusterClient.EXPECT().GetInfraID().Return(infraID, nil).AnyTimes()
 
 			providerVMInstance := New(infraClusterClientMockBuilder, newMockTenantClusterClient)
 			err = providerVMInstance.Create(machine)
@@ -254,6 +256,7 @@ func TestDelete(t *testing.T) {
 			newMockTenantClusterClient.EXPECT().StatusPatchMachine(machine, machine.DeepCopy()).Return(nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetSecret(workerUserDataSecretName, machine.Namespace).Return(stubSecret(), nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetNamespace().Return("kubevirt-actuator-cluster", nil).AnyTimes()
+			newMockTenantClusterClient.EXPECT().GetInfraID().Return(infraID, nil).AnyTimes()
 
 			providerVMInstance := New(infraClusterClientMockBuilder, newMockTenantClusterClient)
 			err = providerVMInstance.Delete(machine)
@@ -353,6 +356,7 @@ func TestExists(t *testing.T) {
 			newMockInfraClusterClient.EXPECT().GetVirtualMachineInstance(clusterID, virtualMachine.Name, gomock.Any()).Return(vmi, nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetSecret(workerUserDataSecretName, machine.Namespace).Return(stubSecret(), nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetNamespace().Return("kubevirt-actuator-cluster", nil).AnyTimes()
+			newMockTenantClusterClient.EXPECT().GetInfraID().Return(infraID, nil).AnyTimes()
 
 			providerVMInstance := New(infraClusterClientMockBuilder, newMockTenantClusterClient)
 			existsVM, err := providerVMInstance.Exists(machine)
@@ -516,6 +520,7 @@ func TestUpdate(t *testing.T) {
 			newMockTenantClusterClient.EXPECT().StatusPatchMachine(machine, machine.DeepCopy()).Return(nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetSecret(workerUserDataSecretName, machine.Namespace).Return(stubSecret(), nil).AnyTimes()
 			newMockTenantClusterClient.EXPECT().GetNamespace().Return("kubevirt-actuator-cluster", nil).AnyTimes()
+			newMockTenantClusterClient.EXPECT().GetInfraID().Return(infraID, nil).AnyTimes()
 
 			providerVMInstance := New(infraClusterClientMockBuilder, newMockTenantClusterClient)
 			// TODO: test the bool wasUpdated

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,9 @@
+package utils
+
+import "fmt"
+
+func BuildLabels(infraID string) map[string]string {
+	return map[string]string{
+		fmt.Sprintf("tenantcluster-%s-machine.openshift.io", infraID): "owned",
+	}
+}


### PR DESCRIPTION
- Add owner label (tenantcluster-<InfraID>-machine.openshift.io:owned) to all VMs
- Fix formatting of ProviderID
